### PR TITLE
Fix aggregation type 'avg' to 'average' for dbt semantic layer compat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ SQL expressions enable:
 - `sum`: Sum of column values
 - `count`: Count of rows
 - `count_distinct`: Count of unique values
-- `avg`: Average of column values
+- `average`: Average of column values (also accepts `avg` which is converted)
 - `min`: Minimum value
 - `max`: Maximum value
 - `median`: Median value (50th percentile)

--- a/examples/metrics/revenue_metrics.yml
+++ b/examples/metrics/revenue_metrics.yml
@@ -40,7 +40,7 @@ metrics:
     label: "AOV"
     source: fct_orders
     measure:
-      type: avg
+      type: average
       column: order_total
       filters:
         - "order_status = 'completed'"

--- a/scripts/compile_metrics.py
+++ b/scripts/compile_metrics.py
@@ -37,9 +37,17 @@ def setup_yaml():
 
 # Supported aggregation types in dbt semantic layer
 SUPPORTED_AGGREGATIONS = [
-    'sum', 'count', 'count_distinct', 'avg', 'min', 'max',
+    'sum', 'count', 'count_distinct', 'average', 'min', 'max',
     'median', 'percentile', 'sum_boolean'
 ]
+
+# Mapping for common abbreviations to correct aggregation types
+AGGREGATION_ALIASES = {
+    'avg': 'average',
+    'cnt': 'count',
+    'cnt_distinct': 'count_distinct',
+    'count_unique': 'count_distinct'
+}
 
 
 class MetricsCompiler:
@@ -174,6 +182,11 @@ class MetricsCompiler:
             # Validate aggregation type if present
             if 'measure' in metric and 'type' in metric['measure']:
                 agg_type = metric['measure']['type']
+                # Check if it's an alias
+                if agg_type in AGGREGATION_ALIASES:
+                    agg_type = AGGREGATION_ALIASES[agg_type]
+                    metric['measure']['type'] = agg_type  # Update to correct type
+                    
                 if agg_type not in SUPPORTED_AGGREGATIONS:
                     raise ValueError(f"Metric '{metric['name']}' has unsupported aggregation type '{agg_type}'. "
                                    f"Supported types: {', '.join(SUPPORTED_AGGREGATIONS)}")
@@ -290,9 +303,14 @@ class MetricsCompiler:
             if 'measure' in metric:
                 measure_name = f"{metric['name']}_measure"
                 if measure_name not in seen_measures:
+                    # Get aggregation type and map aliases
+                    agg_type = metric['measure'].get('type', 'sum')
+                    if agg_type in AGGREGATION_ALIASES:
+                        agg_type = AGGREGATION_ALIASES[agg_type]
+                    
                     measure = {
                         'name': measure_name,
-                        'agg': metric['measure'].get('type', 'sum'),
+                        'agg': agg_type,
                         'expr': metric['measure'].get('column', metric['name'])
                     }
                     
@@ -319,9 +337,14 @@ class MetricsCompiler:
                 if 'numerator' in metric and 'measure' in metric['numerator']:
                     num_measure_name = f"{metric['numerator']['name']}_measure"
                     if num_measure_name not in seen_measures:
+                        # Get aggregation type and map aliases
+                        agg_type = metric['numerator']['measure'].get('type', 'sum')
+                        if agg_type in AGGREGATION_ALIASES:
+                            agg_type = AGGREGATION_ALIASES[agg_type]
+                        
                         num_measure = {
                             'name': num_measure_name,
-                            'agg': metric['numerator']['measure'].get('type', 'sum'),
+                            'agg': agg_type,
                             'expr': metric['numerator']['measure'].get('column', metric['numerator']['name'])
                         }
                         if 'agg_params' in metric['numerator']['measure']:
@@ -338,9 +361,14 @@ class MetricsCompiler:
                 if 'denominator' in metric and 'measure' in metric['denominator']:
                     den_measure_name = f"{metric['denominator']['name']}_measure"
                     if den_measure_name not in seen_measures:
+                        # Get aggregation type and map aliases
+                        agg_type = metric['denominator']['measure'].get('type', 'sum')
+                        if agg_type in AGGREGATION_ALIASES:
+                            agg_type = AGGREGATION_ALIASES[agg_type]
+                        
                         den_measure = {
                             'name': den_measure_name,
-                            'agg': metric['denominator']['measure'].get('type', 'sum'),
+                            'agg': agg_type,
                             'expr': metric['denominator']['measure'].get('column', metric['denominator']['name'])
                         }
                         if 'agg_params' in metric['denominator']['measure']:
@@ -358,9 +386,14 @@ class MetricsCompiler:
                 if 'measure' in metric and 'measure' in metric['measure']:
                     cum_measure_name = f"{metric['measure']['name']}_measure"
                     if cum_measure_name not in seen_measures:
+                        # Get aggregation type and map aliases
+                        agg_type = metric['measure']['measure'].get('type', 'sum')
+                        if agg_type in AGGREGATION_ALIASES:
+                            agg_type = AGGREGATION_ALIASES[agg_type]
+                        
                         cum_measure = {
                             'name': cum_measure_name,
-                            'agg': metric['measure']['measure'].get('type', 'sum'),
+                            'agg': agg_type,
                             'expr': metric['measure']['measure'].get('column', metric['measure']['name'])
                         }
                         if 'agg_params' in metric['measure']['measure']:


### PR DESCRIPTION
…ibility

dbt semantic layer expects 'average' not 'avg' as the aggregation type. This was causing: "Invalid enum value: 'avg' in enum AggregationType"

Changes:
- Update SUPPORTED_AGGREGATIONS to use 'average' instead of 'avg'
- Add AGGREGATION_ALIASES mapping to convert common abbreviations:
  - 'avg' → 'average'
  - 'cnt' → 'count'
  - 'cnt_distinct' → 'count_distinct'
  - 'count_unique' → 'count_distinct'
- Apply alias mapping in validation and all measure building code
- Update documentation to reflect 'average' as the correct type
- Fix example files to use 'average' instead of 'avg'

This maintains backward compatibility by automatically converting 'avg' to 'average'.

🤖 Generated with [Claude Code](https://claude.ai/code)